### PR TITLE
Tokinominoru Kinen -> Kyodo News Hai

### DIFF
--- a/src/data/race-name.csv
+++ b/src/data/race-name.csv
@@ -316,7 +316,7 @@
 "信越ステークス","Shinetsu Stakes"
 "六甲S","Rokko S"
 "六甲ステークス","Rokko Stakes"
-"共同通信杯","Tokinominoru Kinen"
+"共同通信杯","Kyodo News Hai"
 "函館ジュニアS","Hakodate Junior S"
 "函館ジュニアステークス","Hakodate Junior Stakes"
 "函館スプリントS","Hakodate Sprint S"


### PR DESCRIPTION
Fixed version of #82.

"Tokinominoru Kinen" is not actually the official name of the race, but a subtitle. While it is an official subtitle (「競馬番組表での名称は「共同通信杯（トキノミノル記念）」と表記される」, see https://ja.wikipedia.org/wiki/%E5%85%B1%E5%90%8C%E9%80%9A%E4%BF%A1%E6%9D%AF), the actual name is "Kyodo News Hai".

The fact that an english wiki page exists under the name Tokinominoru Kinen (https://en.wikipedia.org/wiki/Tokinominoru_Kinen) made me miss this fact.